### PR TITLE
Little improvements

### DIFF
--- a/mudle-enhancer.user.js
+++ b/mudle-enhancer.user.js
@@ -45,7 +45,9 @@ function cleanModuleNames() {
 function trimModule(title) {
     const semesterMatch = title.match(/\s\(\d*-\d*:[\w\d\s-]*\)/);
 
-    return title.substring(0, semesterMatch ? semesterMatch.index : undefined)
+    return title
+        .substring(0, semesterMatch ? semesterMatch.index : undefined)
+        .replace(/\[\w\]/, "");
 }
 
 /* ----------------------------------------------------------------- 

--- a/mudle-enhancer.user.js
+++ b/mudle-enhancer.user.js
@@ -45,7 +45,7 @@ function cleanModuleNames() {
 function trimModule(title) {
     const cutPoint = title.indexOf('(2019');
 
-    return title.substring(0, cutPoint > 0 ? cutPoint : null);
+    return title.substring(0, cutPoint > 0 ? cutPoint : undefined);
 }
 
 /* ----------------------------------------------------------------- 

--- a/mudle-enhancer.user.js
+++ b/mudle-enhancer.user.js
@@ -45,11 +45,7 @@ function cleanModuleNames() {
 function trimModule(title) {
     const cutPoint = title.indexOf('(2019');
 
-    if (cutPoint > 0) {
-        return title.substring(0, cutPoint > 0 ? cutPoint : null);
-    }
-
-    return title;
+    return title.substring(0, cutPoint > 0 ? cutPoint : null);
 }
 
 /* ----------------------------------------------------------------- 

--- a/mudle-enhancer.user.js
+++ b/mudle-enhancer.user.js
@@ -43,9 +43,9 @@ function cleanModuleNames() {
 }
 
 function trimModule(title) {
-    const cutPoint = title.indexOf('(2019');
+    const semesterMatch = title.match(/\s\(\d*-\d*:[\w\d\s-]*\)/);
 
-    return title.substring(0, cutPoint > 0 ? cutPoint : undefined);
+    return title.substring(0, semesterMatch ? semesterMatch.index : undefined)
 }
 
 /* ----------------------------------------------------------------- 

--- a/mudle-enhancer.user.js
+++ b/mudle-enhancer.user.js
@@ -20,6 +20,7 @@
  *
  * Clean up module names
  * Replaces "(Year:Semester)" with the title of the module 
+ * and removes [X] from after module codes
  *
  * ----------------------------------------------------------------- */
 


### PR DESCRIPTION
Some small improvements such as fixing the ternary operator (`undefined` instead of `null`, since `null` still counts as a parameter).

Use regex for finding the string at the end to trim off so it'll work forever and ever.

Removes the [X] on module names, so MT434P[A] becomes MT434 (since logically, modules are sorted by past, current and future. So a student won't be doing parts A, B simultaneously. So there shouldn't be any ambiguity).
